### PR TITLE
improvements; * add more complex on_close() handler

### DIFF
--- a/sub.py
+++ b/sub.py
@@ -55,9 +55,7 @@ class Sub(Element, Processor):
                 raise FileNotFoundError("File could not be loaded.")
             pwin = window.PynoWindow(pyglet.gl.Config(),
                                      filename=self.code,
-                                     caption='→ ' + self.name,
-                                     style=pyglet.window.Window.WINDOW_STYLE_BORDERLESS)
-            pwin.set_location(0,0)
+                                     caption='→ ' + self.name)
             if self.pwindow:
                 self.pwindow.close()
                 del self.pwindow

--- a/window.py
+++ b/window.py
@@ -377,10 +377,12 @@ class PynoWindow(pyglet.window.Window):
                 for node in self.selected_nodes:
                     print(str(node))
 
-    def on_close(self):
+    def on_close(self, force=False):
+        if (not self.caption == "Pyno") and (not force):  # is this the root/main window?
+            return True
         for node in self.nodes:
             if isinstance(node, Sub) and node.pwindow:
-                node.pwindow.on_close()
+                node.pwindow.on_close(force=True)
         menu.autosave(menu.copy_nodes(self, data=True))
         self.close()
 


### PR DESCRIPTION
improvements;
* add more complex on_close() handler in order to make sub windows more usable by adding border

Found a possible (better?) solution by adding an optional parameter `force` to the `on_close()` event handler. It is still a bit hacky as it detects the root/main window by checking for `self.caption == "Pyno"`. I think you might like this more?