### PR TITLE
improvements; * add code hint label ("autocomplete")

### DIFF
--- a/codeEditor.py
+++ b/codeEditor.py
@@ -161,7 +161,7 @@ class CodeEditor(object):
                     start = newline_offset[item.start[0] - 1] + item.start[1]
                     stopp = newline_offset[item.end[0] - 1] + item.end[1] + 1
                     # rudimentary autocomplete hint
-                    if (start <= self.caret.position) and (self.caret.position <= stopp):
+                    if (start <= self.caret.position <= stopp):
                         try:
                             obj = eval(item.string)
                             #print("Code hint:\n", obj.__doc__)

--- a/codeEditor.py
+++ b/codeEditor.py
@@ -18,9 +18,11 @@ class CodeEditor(object):
     Code editor is the window you define nodes function
     '''
 
-    def __init__(self, node):
+    def __init__(self, node, highlighting=True):
         self.node = node  # node-owner of this codeEditor
         self.document = pyglet.text.document.FormattedDocument(node.code)
+
+        self.highlighting = highlighting
 
         @self.document.event
         def on_insert_text(start, end):
@@ -145,6 +147,10 @@ class CodeEditor(object):
         self.document.set_style(0, len(self.node.code),
                                 dict(color=(255, 255, 255, 255)))
         self.autocomplete.text = ""
+
+        if not self.highlighting:
+            return
+
         # rudimentary syntax highlighting and autocomplete hint
         newline_offset = ([0] +
                           [i for i, ch in enumerate(self.document.text) if ch == '\n'] +

--- a/codeEditor.py
+++ b/codeEditor.py
@@ -163,7 +163,7 @@ class CodeEditor(object):
                     # rudimentary autocomplete hint
                     if (start <= self.caret.position <= stopp):
                         try:
-                            obj = eval(item.string)
+                            obj = eval(item.string, self.node.env)
                             #print("Code hint:\n", obj.__doc__)
                             self.autocomplete.text = obj.__doc__.split("\n")[0]
                         except:
@@ -194,6 +194,7 @@ class CodeEditor(object):
         elif button == 1 and self.hover:
             self.set_focus()
             self.caret.on_mouse_press(x, y, button, modifiers)
+            self.update_highlighting()
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
         x, y = x_y_pan_scale(x, y, self.pan_scale, self.screen_size)

--- a/codeEditor.py
+++ b/codeEditor.py
@@ -3,6 +3,7 @@ import pyperclip
 import keyword
 import tokenize
 import io
+import os
 
 from utils import x_y_pan_scale, font
 from draw import quad_aligned
@@ -18,11 +19,11 @@ class CodeEditor(object):
     Code editor is the window you define nodes function
     '''
 
-    def __init__(self, node, highlighting=True):
+    def __init__(self, node, highlighting=1):
         self.node = node  # node-owner of this codeEditor
         self.document = pyglet.text.document.FormattedDocument(node.code)
 
-        self.highlighting = highlighting
+        self.highlighting = highlighting  # 0: off, 1: python (node), 2: file (sub)
 
         @self.document.event
         def on_insert_text(start, end):
@@ -148,36 +149,40 @@ class CodeEditor(object):
                                 dict(color=(255, 255, 255, 255)))
         self.autocomplete.text = ""
 
-        if not self.highlighting:
+        if self.highlighting == 0:    # 0: off
             return
-
-        # rudimentary syntax highlighting and autocomplete hint
-        newline_offset = ([0] +
-                          [i for i, ch in enumerate(self.document.text) if ch == '\n'] +
-                          [len(self.document.text)])
-        try:
-            for item in tokenize.tokenize(io.BytesIO(self.document.text.encode('utf-8')).readline):
-                start = newline_offset[item.start[0] - 1] + item.start[1]
-                stopp = newline_offset[item.end[0] - 1] + item.end[1] + 1
-                # rudimentary autocomplete hint
-                if (start <= self.caret.position) and (self.caret.position <= stopp):
-                    try:
-                        obj = eval(item.string)
-                        #print("Code hint:\n", obj.__doc__)
-                        self.autocomplete.text = obj.__doc__.split("\n")[0]
-                    except:
+        elif self.highlighting == 1:  # 1: python
+            # rudimentary syntax highlighting and autocomplete hint
+            newline_offset = ([0] +
+                              [i for i, ch in enumerate(self.document.text) if ch == '\n'] +
+                              [len(self.document.text)])
+            try:
+                for item in tokenize.tokenize(io.BytesIO(self.document.text.encode('utf-8')).readline):
+                    start = newline_offset[item.start[0] - 1] + item.start[1]
+                    stopp = newline_offset[item.end[0] - 1] + item.end[1] + 1
+                    # rudimentary autocomplete hint
+                    if (start <= self.caret.position) and (self.caret.position <= stopp):
+                        try:
+                            obj = eval(item.string)
+                            #print("Code hint:\n", obj.__doc__)
+                            self.autocomplete.text = obj.__doc__.split("\n")[0]
+                        except:
+                            pass
+                    # syntax highlighting
+                    if (item.type == tokenize.NAME) and (item.string in highlight):
                         pass
-                # syntax highlighting
-                if (item.type == tokenize.NAME) and (item.string in highlight):
-                    pass
-                elif (item.type in [tokenize.COMMENT, tokenize.OP, tokenize.NUMBER, tokenize.STRING]):
-                    start = start + 1
-                else:
-                    continue  # do not highlight this token
-                self.document.set_style(start, stopp,
+                    elif (item.type in [tokenize.COMMENT, tokenize.OP, tokenize.NUMBER, tokenize.STRING]):
+                        start = start + 1
+                    else:
+                        continue  # do not highlight this token
+                    self.document.set_style(start, stopp,
+                                            dict(color=(255, 200, 100, 255)))
+            except tokenize.TokenError:
+                pass
+        elif self.highlighting == 2:  # 2: file
+            if os.path.exists(self.document.text):
+                self.document.set_style(0, len(self.node.code),
                                         dict(color=(255, 200, 100, 255)))
-        except tokenize.TokenError:
-            pass
 
     # --- Input events ---
 
@@ -233,17 +238,29 @@ class CodeEditor(object):
 
         elif modifiers & key.MOD_CTRL:
             if symbol == key.C and self.caret.mark:
-                start = min(self.caret.position, self.caret.mark)
-                end = max(self.caret.position, self.caret.mark)
-                text = self.document.text[start:end]
-                pyperclip.copy(text)
+                self.copy_text()
             elif symbol == key.V:
+                start = min(self.caret.position, self.caret.mark or self.caret.position)
+                end = max(self.caret.position, self.caret.mark or self.caret.position)
                 text = pyperclip.paste()
+                self.document.delete_text(start, end)
                 self.document.insert_text(self.caret.position, text)
                 self.caret.position += len(text)
+                self.caret.mark = self.caret.position
+            elif symbol == key.X and self.caret.mark:
+                start, end = self.copy_text()
+                self.document.delete_text(start, end)
+                self.caret.mark = self.caret.position
 
         elif symbol == key.BACKSPACE or symbol == key.DELETE:
             self.change = True
+
+    def copy_text(self):
+        start = min(self.caret.position, self.caret.mark)
+        end = max(self.caret.position, self.caret.mark)
+        text = self.document.text[start:end]
+        pyperclip.copy(text)
+        return (start, end)
 
     def set_focus(self):
         self.caret.visible = True

--- a/field.py
+++ b/field.py
@@ -271,4 +271,7 @@ class Field(Element):
 
     def lost_focus(self):
         self.caret.visible = False
-        self.caret.mark = self.caret.position = 0
+        try:
+            self.caret.mark = self.caret.position = 0
+        except AttributeError:
+            pass  # work-a-round for https://github.com/honix/Pyno/issues/12

--- a/node.py
+++ b/node.py
@@ -35,6 +35,8 @@ class Node(Element, Processor):
 
 call = newNode'''
 
+        self.env = {}
+
         self.name = ''
         self.label = pyglet.text.Label(self.name, font_name=font,
                                        bold=True, font_size=11,
@@ -51,9 +53,9 @@ call = newNode'''
 
         self.func = None
         try:
-            env = {'S': self.local_space, 'G': self.window.pyno_namespace}
-            exec(code, env)
-            self.func = env['call']
+            self.env = {'S': self.local_space, 'G': self.window.pyno_namespace}
+            exec(code, self.env)
+            self.func = self.env['call']
             if not isinstance(self.func, types.FunctionType):
                 raise Exception('Call value is not callable!')
         except Exception as ex:

--- a/window.py
+++ b/window.py
@@ -249,7 +249,7 @@ class PynoWindow(pyglet.window.Window):
                             self.push_handlers(node)
                             self.field = node
                         elif isinstance(node, Sub):
-                            self.code_editor = CodeEditor(node)
+                            self.code_editor = CodeEditor(node, highlighting=False)
                             node.pwindow.set_visible(not node.pwindow.visible)
                         self.selected_nodes = [node]
                         self.node_drag = True

--- a/window.py
+++ b/window.py
@@ -249,7 +249,7 @@ class PynoWindow(pyglet.window.Window):
                             self.push_handlers(node)
                             self.field = node
                         elif isinstance(node, Sub):
-                            self.code_editor = CodeEditor(node, highlighting=False)
+                            self.code_editor = CodeEditor(node, highlighting=2)
                             node.pwindow.set_visible(not node.pwindow.visible)
                         self.selected_nodes = [node]
                         self.node_drag = True


### PR DESCRIPTION
This is a proposal. One should may be not call this autocomplete. It is more a code hint system, it evaluates the expression on and returns the first line of its doc-string.

The placement of the label is not optimal, but I could not figure out a better place (all I tried looked even uglier ;).