### PR TITLE
simplify running pyno with the interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ pip install git+https://github.com/honix/Pyno.git
 
 Then you can run ```pyno``` in a console from anywhere. 
 
-If you want to work with just the project repository, i.e. without installing the package (this is not recommended!), open a python console in the repository root directory, and run
+If you want to work with just the project repository, i.e. without installing the package (this is not recommended!), run `python -m pyno` in a console, or open a python console in the repository root directory, and run
 ```
 import pyno
 pyno.app_run()

--- a/pyno/__main__.py
+++ b/pyno/__main__.py
@@ -1,0 +1,5 @@
+"""Provide a way to run pyno using the Python interpreter directly."""
+
+from .window import app_run
+
+app_run()

--- a/pyno/run.py
+++ b/pyno/run.py
@@ -1,7 +1,0 @@
-import pyno
-
-def main():
-    pyno.app_run()
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
This makes running pyno using the interpreter slightly more pythonic and simpler, you just do `python -m pyno`. 
Slight benefit compared to before: this additionally works from all directories if one has installed pyno with pip.